### PR TITLE
fix: throw an error on plugin warnings when creating the colif manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "bugs": "https://github.com/oclif/dev-cli/issues",
   "dependencies": {
     "@oclif/command": "^1.4.1",
-    "@oclif/config": "^1.3.57",
+    "@oclif/config": "^1.3.59",
     "@oclif/errors": "^1.0.2",
     "@oclif/plugin-help": "^1.1.5",
     "lodash": "^4.17.5",

--- a/src/commands/manifest.ts
+++ b/src/commands/manifest.ts
@@ -11,25 +11,13 @@ export default class Manifest extends Command {
     {name: 'path', description: 'path to plugin', default: '.'}
   ]
 
-  capturePluginWarning(warning: Error) {
-    if (warning.name.match(/Plugin:/)) { throw warning }
-  }
-
   async run() {
     try { fs.unlinkSync('.oclif.manifest.json') } catch {}
     const {args} = this.parse(Manifest)
     const root = path.resolve(args.path)
-    let plugin = new Config.Plugin({root, type: 'core', ignoreManifest: true})
+    let plugin = new Config.Plugin({root, type: 'core', ignoreManifest: true, errorOnManifestCreate: true})
     if (!plugin) throw new Error('plugin not found')
-    process.addListener('warning', this.capturePluginWarning)
-    try {
-      await plugin.load()
-      // Wait for event queue to flush so we get any potential warning.
-      await new Promise(resolve => process.nextTick(resolve))
-    } finally {
-      // Clean up
-      process.removeListener('warning', this.capturePluginWarning)
-    }
+    await plugin.load()
     if (!plugin.valid) {
       // @ts-ignore
       let p = require.resolve('@oclif/plugin-legacy', {paths: [process.cwd()]})


### PR DESCRIPTION
Displaying warnings when parsing plugin makes sense, however, the warnings can be hard to spot when generating the manifest during plugin development.

This fix will catch the plugin warning emitted by the process and throw the error.