### PR TITLE
Checks earlier if macos.identifier is set

### DIFF
--- a/src/commands/pack/macos.ts
+++ b/src/commands/pack/macos.ts
@@ -14,6 +14,7 @@ export default class PackMacos extends Command {
 
   async run() {
     if (process.platform !== 'darwin') this.error('must be run from macos')
+    if (!c.macos || !c.macos.identifier) this.error('package.json must have oclif.macos.identifier set')
     const {flags} = this.parse(PackMacos)
     const buildConfig = await Tarballs.buildConfig(flags.root)
     const {config} = buildConfig
@@ -29,7 +30,6 @@ export default class PackMacos extends Command {
     await writeScript('preinstall')
     await writeScript('postinstall')
     const c = config.pjson.oclif as any
-    if (!c.macos || !c.macos.identifier) this.error('package.json must have oclif.macos.identifier set')
     const args = [
       '--root', buildConfig.workspace({platform: 'darwin', arch: 'x64'}),
       '--identifier', c.macos.identifier,

--- a/src/commands/pack/macos.ts
+++ b/src/commands/pack/macos.ts
@@ -14,10 +14,11 @@ export default class PackMacos extends Command {
 
   async run() {
     if (process.platform !== 'darwin') this.error('must be run from macos')
-    if (!c.macos || !c.macos.identifier) this.error('package.json must have oclif.macos.identifier set')
     const {flags} = this.parse(PackMacos)
     const buildConfig = await Tarballs.buildConfig(flags.root)
     const {config} = buildConfig
+    const c = config.pjson.oclif as any
+    if (!c.macos || !c.macos.identifier) this.error('package.json must have oclif.macos.identifier set')
     await Tarballs.build(buildConfig, {platform: 'darwin', pack: false})
     const dist = buildConfig.dist(`macos/${config.bin}-v${buildConfig.version}.pkg`)
     await qq.emptyDir(path.dirname(dist))
@@ -29,7 +30,6 @@ export default class PackMacos extends Command {
     }
     await writeScript('preinstall')
     await writeScript('postinstall')
-    const c = config.pjson.oclif as any
     const args = [
       '--root', buildConfig.workspace({platform: 'darwin', arch: 'x64'}),
       '--identifier', c.macos.identifier,


### PR DESCRIPTION
I think it makes sense to check this in the beginning of the script and not after the tarball has been build. Will save time for new users.