### PR TITLE
Modify prune to only remove *.d.ts files, not all .ts files

### DIFF
--- a/src/tarballs/build.ts
+++ b/src/tarballs/build.ts
@@ -66,7 +66,7 @@ export async function build(c: IConfig, options: {
     const toRemove = await qq.globby([
       'node_modules/**/README*',
       '**/CHANGELOG*',
-      '**/*.ts',
+      '**/*.d.ts',
     ], {nocase: true})
     await qq.rm(...toRemove)
     await qq.rmIfEmpty('.')


### PR DESCRIPTION
When building a CLI with code scaffolding you might have some necessary .ts template files. At the moment those files would just disappear and the CLI obviously is not able to find the templates.
Removing just the .d.ts files fixes this issue.