### PR TITLE
Remove extra spaces around TOC items

### DIFF
--- a/src/commands/readme.ts
+++ b/src/commands/readme.ts
@@ -71,7 +71,7 @@ Customize the code URL prefix by setting oclif.repositoryPrefix in package.json.
 
   toc(__: Config.IConfig, readme: string): string {
     return readme.split('\n').filter(l => l.startsWith('# '))
-      .map(l => l.slice(2))
+      .map(l => l.trim().slice(2))
       .map(l => `* [${l}](#${slugify(l)})`)
       .join('\n')
   }


### PR DESCRIPTION
In some cases (mine being CRLF related) you may have whitespace chars trailing TOC items. This patch `trim()`s the problem away.