### PR TITLE
Allow custom "acl" key in oclif.update.s3

### DIFF
--- a/src/commands/publish/deb.ts
+++ b/src/commands/publish/deb.ts
@@ -20,7 +20,7 @@ export default class PublishDeb extends Command {
     if (!await qq.exists(dist('Release'))) this.error('run "oclif-dev pack:deb" before publishing')
     const S3Options = {
       Bucket: s3Config.bucket!,
-      ACL: 'public-read',
+      ACL: s3Config.acl || 'public-read',
     }
 
     const remoteBase = buildConfig.channel === 'stable' ? 'apt' : `channels/${buildConfig.channel}/apt`

--- a/src/commands/publish/index.ts
+++ b/src/commands/publish/index.ts
@@ -27,7 +27,7 @@ export default class Publish extends Command {
     if (!await qq.exists(dist(config.s3Key('versioned', {ext: '.tar.gz'})))) this.error('run "oclif-dev pack" before publishing')
     const S3Options = {
       Bucket: s3Config.bucket!,
-      ACL: 'public-read',
+      ACL: s3Config.acl || 'public-read',
     }
     // for (let target of targets) await this.uploadNodeBinary(target)
     const ManifestS3Options = {...S3Options, CacheControl: 'max-age=86400', ContentType: 'application/json'}

--- a/src/commands/publish/macos.ts
+++ b/src/commands/publish/macos.ts
@@ -18,7 +18,7 @@ export default class PublishMacos extends Command {
     const {s3Config, version, config} = buildConfig
     const S3Options = {
       Bucket: s3Config.bucket!,
-      ACL: 'public-read',
+      ACL: s3Config.acl || 'public-read',
     }
 
     let root = buildConfig.channel === 'stable' ? '' : `channels/${buildConfig.channel}/`

--- a/src/commands/publish/win.ts
+++ b/src/commands/publish/win.ts
@@ -18,7 +18,7 @@ export default class PublishWin extends Command {
     const {s3Config, version, config} = buildConfig
     const S3Options = {
       Bucket: s3Config.bucket!,
-      ACL: 'public-read',
+      ACL: s3Config.acl || 'public-read',
     }
 
     let root = buildConfig.channel === 'stable' ? '' : `channels/${buildConfig.channel}/`


### PR DESCRIPTION
I'm interested in contributing a new feature: a custom `acl` key to be used in the `package.json` file that would allow the developer to specify a custom AWS ACL to use when uploading versions of their CLI.

We're maintaining a CLI built on oclif that's only intended for private use within the org. We achieve this by publishing it to an S3 bucket that has an ACL configured to only allow reads from private IP addresses. This requires that when we upload objects to the bucket that we specify an ACL of "private'. The `publish` commands were hardcoding an ACL of "public-read" but this would allow them to be more flexible.