### PR TITLE
Configure S3 endpoint from env variable

### DIFF
--- a/src/aws.ts
+++ b/src/aws.ts
@@ -31,7 +31,10 @@ const aws = {
   },
   get s3() {
     try {
-      return cache.s3 = cache.s3 || new (require('aws-sdk/clients/s3') as typeof S3)(this.creds)
+      return cache.s3 = cache.s3 || new (require('aws-sdk/clients/s3') as typeof S3)({
+        ...this.creds,
+        endpoint: process.env.AWS_S3_ENDPOINT,
+      })
     } catch (err) {
       if (err.code === 'MODULE_NOT_FOUND') throw new Error(`${err.message}\naws-sdk is needed to run this command.\nInstall aws-sdk as a devDependency in your CLI. \`yarn add -D aws-sdk\``)
       throw err


### PR DESCRIPTION
This PR lets you publish to any S3 compatible host (eg DigitalOcean Spaces) using `AWS_S3_ENDPOINT`. Existing behavior remains the same if unset.