### PR TITLE
Check for babel and look for src files if present.

### DIFF
--- a/src/commands/readme.ts
+++ b/src/commands/readme.ts
@@ -189,7 +189,16 @@ USAGE
     if (!commandsDir) return
     let p = path.join(plugin.root, commandsDir, ...c.id.split(':'))
     const libRegex = new RegExp('^lib' + (path.sep === '\\' ? '\\\\' : path.sep))
-    if (fs.pathExistsSync(path.join(p, 'index.js'))) {
+    if (plugin.pjson.devDependencies['@babel/core']) {
+      // check for non-compiled scripts if using babel
+      let base = p.replace(plugin.root + path.sep, '')
+      p = path.join(plugin.root, base.replace(libRegex, 'src' + path.sep))
+      if (fs.pathExistsSync(path.join(p, 'index.js'))) {
+        p = path.join(p, 'index.js')
+      } else if (fs.pathExistsSync(p + '.js')) {
+        p = p + '.js'
+      }
+    } else if (fs.pathExistsSync(path.join(p, 'index.js'))) {
       p = path.join(p, 'index.js')
     } else if (fs.pathExistsSync(p + '.js')) {
       p = p + '.js'


### PR DESCRIPTION
Echos the pattern already present for typescript, but extends this to js files for projects that are using javascript with babel and want the links to refer to the `src` files rather than `lib`.