### PR TITLE
Standardize directory separator in command path

### DIFF
--- a/src/commands/readme.ts
+++ b/src/commands/readme.ts
@@ -164,7 +164,7 @@ USAGE
     let commandPath = this.commandPath(plugin, c)
     if (!commandPath) return
     if (config.name === plugin.name) {
-      label = commandPath
+      label = commandPath.replace(/\\/g, '/')
       version = process.env.OCLIF_NEXT_VERSION || version
     }
     const template = plugin.pjson.oclif.repositoryPrefix || '<%- repo %>/blob/v<%- version %>/<%- commandPath %>'


### PR DESCRIPTION
README now displays standard `/` directory separator even if ran on Windows