### PR TITLE
fix: run oclif-dev pack:deb as non root user

### DIFF
--- a/src/commands/pack/deb.ts
+++ b/src/commands/pack/deb.ts
@@ -42,8 +42,8 @@ export default class PackDeb extends Command {
       await qq.write([workspace, 'DEBIAN/control'], scripts.control(buildConfig, debArch(arch)))
       await qq.chmod([workspace, 'usr/lib', config.dirname, 'bin', config.bin], 0o755)
       await qq.x(`ln -s "../lib/${config.dirname}/bin/${config.bin}" "${workspace}/usr/bin/${config.bin}"`)
-      await qq.x(`chown -R root "${workspace}"`)
-      await qq.x(`chgrp -R root "${workspace}"`)
+      await qq.x(`sudo chown -R root "${workspace}"`)
+      await qq.x(`sudo chgrp -R root "${workspace}"`)
       await qq.x(`dpkg --build "${workspace}" "${qq.join(dist, `${versionedDebBase}.deb`)}"`)
     }
 


### PR DESCRIPTION
The only part of the pack:deb command that requires root are the chown and chgrp shell commands. I don't run oclif-dev as root, so the command fails at this point. By adding sudo, it asks for the password and only runs these commands with root privileges, which seems sensible to me.
The change will have no effect if already running with root privileges.