### PR TITLE
Don't fail if project is not a Git repo.

### DIFF
--- a/test/deb.test.ts
+++ b/test/deb.test.ts
@@ -1,7 +1,7 @@
 import {expect, test} from '@oclif/test'
 import * as qq from 'qqjs'
 
-import {gitSha} from '../src/tarballs'
+import {getVcsRevision} from '../src/tarballs'
 
 const pjson = require('../package.json')
 const pjsonPath = require.resolve('../package.json')
@@ -31,7 +31,7 @@ describe('publish:deb', () => {
   .command(['pack:deb'])
   .command(['publish:deb'])
   .it('publishes valid releases', async () => {
-    const sha = await gitSha(process.cwd(), {short: true})
+    const sha = await getVcsRevision(process.cwd(), {short: true})
     qq.cd([__dirname, '..'])
     await qq.x('cat test/release.key | apt-key add -')
     await qq.x(`echo "deb https://oclif-staging.s3.amazonaws.com/channels/${testRun}/apt ./" > /etc/apt/sources.list.d/oclif-dev.list`)

--- a/test/publish.test.ts
+++ b/test/publish.test.ts
@@ -2,7 +2,7 @@ import {expect, test} from '@oclif/test'
 import * as qq from 'qqjs'
 
 import aws from '../src/aws'
-import {gitSha} from '../src/tarballs'
+import {getVcsRevision} from '../src/tarballs'
 
 const pjson = require('../package.json')
 const pjsonPath = require.resolve('../package.json')
@@ -47,7 +47,7 @@ describe('publish', () => {
           await qq.x('tar xzf oclif-dev.tar.gz')
         }
         const stdout = await qq.x.stdout('./oclif-dev/bin/oclif-dev', ['--version'])
-        const sha = await gitSha(process.cwd(), {short: true})
+        const sha = await getVcsRevision(process.cwd(), {short: true})
         expect(stdout).to.contain(`@oclif/dev-cli/${pjson.version}.${sha} ${target} node-v${nodeVersion}`)
         await qq.rm('oclif-dev')
       }


### PR DESCRIPTION
Hi I ran into #71 when building in Docker, this code change is intended to not call git if it's not in a git repo. I've also made the variable name generic in case you want to support version control systems in the future.