### PR TITLE
fix: find yarn.lock in a yarn workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@oclif/plugin-help": "^2.1.6",
     "cli-ux": "^5.2.1",
     "debug": "^4.1.1",
+    "find-yarn-workspace-root": "^2.0.0",
     "fs-extra": "^7.0.1",
     "github-slugger": "^1.2.1",
     "lodash": "^4.17.11",

--- a/src/tarballs/build.ts
+++ b/src/tarballs/build.ts
@@ -1,5 +1,6 @@
 import {ArchTypes, PlatformTypes} from '@oclif/config'
 import * as Errors from '@oclif/errors'
+import * as findYarnWorkspaceRoot from 'find-yarn-workspace-root'
 import * as path from 'path'
 import * as qq from 'qqjs'
 
@@ -52,9 +53,10 @@ export async function build(c: IConfig, options: {
   }
   const addDependencies = async () => {
     qq.cd(c.workspace())
-    const yarn = await qq.exists.sync([c.root, 'yarn.lock'])
+    const yarnRoot = findYarnWorkspaceRoot(c.root) || c.root
+    const yarn = await qq.exists([yarnRoot, 'yarn.lock'])
     if (yarn) {
-      await qq.cp([c.root, 'yarn.lock'], '.')
+      await qq.cp([yarnRoot, 'yarn.lock'], '.')
       await qq.x('yarn --no-progress --production --non-interactive')
     } else {
       let lockpath = qq.join(c.root, 'package-lock.json')

--- a/yarn.lock
+++ b/yarn.lock
@@ -1615,6 +1615,13 @@ find-up@^4.0.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-yarn-workspace-root@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd"
+  integrity sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==
+  dependencies:
+    micromatch "^4.0.2"
+
 flat-cache@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"


### PR DESCRIPTION
Hi there, thanks for developing oclif, it's been great to work with.

I've got an oclif-based CLI as one of my packages in a yarn workspaces setup. Since the yarn.lock is not in the package itself but in the workspace root, `oclif-dev pack` fails to find the yarn.lock on this line:

https://github.com/oclif/dev-cli/blob/f3d1fee09b70cf88b480cad6e7200f0938803701/src/tarballs/build.ts#L55

This change tries to find the yarn workspace root and, if found, uses it to find the yarn.lock.

Resolves #125 