### PR TITLE
ci: remove .circleci/loadgpg step from test workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,6 @@ jobs:
             - v6-yarn-{{checksum ".circleci/config.yml"}}
       - run: 'echo "Node: `node --version`"'
       - run: yarn
-      - run: .circleci/loadgpg
       - run: yarn add -D nyc@13 @oclif/nyc-config@1
       - run: ./node_modules/.bin/tsc
       - run: ./bin/run --version


### PR DESCRIPTION
We don’t make the necessary env vars available to fork PRs. As a result any fork PRs fail due the missing gpg secret key. It looks like we don’t use the key anyway for the test workflow, so it seems reasonable to remove this step.