### PR TITLE
Use `require` to check if the project uses TypeScript

### DIFF
--- a/src/commands/readme.ts
+++ b/src/commands/readme.ts
@@ -203,11 +203,15 @@ USAGE
     if (!commandsDir) return
     let p = path.join(plugin.root, commandsDir, ...c.id.split(':'))
     const libRegex = new RegExp('^lib' + (path.sep === '\\' ? '\\\\' : path.sep))
+    let typescript
+    try {
+      typescript = require('typescript')
+    } catch {}
     if (fs.pathExistsSync(path.join(p, 'index.js'))) {
       p = path.join(p, 'index.js')
     } else if (fs.pathExistsSync(p + '.js')) {
       p += '.js'
-    } else if (plugin.pjson.devDependencies && plugin.pjson.devDependencies.typescript) {
+    } else if (typescript) {
       // check if non-compiled scripts are available
       const base = p.replace(plugin.root + path.sep, '')
       p = path.join(plugin.root, base.replace(libRegex, 'src' + path.sep))
@@ -218,7 +222,7 @@ USAGE
       } else return
     } else return
     p = p.replace(plugin.root + path.sep, '')
-    if (plugin.pjson.devDependencies && plugin.pjson.devDependencies.typescript) {
+    if (typescript) {
       p = p.replace(libRegex, 'src' + path.sep)
       p = p.replace(/\.js$/, '.ts')
     }


### PR DESCRIPTION
Motivation: I have an oclif project as a package in a yarn workspaces monorepo. When running `oclif-dev readme`, the command path in the "_See code_" entries isn't correct. I found out that this is because it's looking for TypeScript in the devDependencies to determine if TypeScript is being used. I have TypeScript in the root devDependencies of my monorepo, not in the package devDependencies.

To solve this, this PR proposes that instead of checking the package's devDependencies to determine if the package uses TypeScript, try to `require('typescript')` and use success as an indicator that the package uses TypeScript. This allows TypeScript to be detected even if it is not listed in the project's dependencies.