### PR TITLE
fix: dont duplicate README blocks for CRLF

### DIFF
--- a/src/commands/readme.ts
+++ b/src/commands/readme.ts
@@ -64,7 +64,7 @@ Customize the code URL prefix by setting oclif.repositoryPrefix in package.json.
   replaceTag(readme: string, tag: string, body: string): string {
     if (readme.includes(`<!-- ${tag} -->`)) {
       if (readme.includes(`<!-- ${tag}stop -->`)) {
-        readme = readme.replace(new RegExp(`<!-- ${tag} -->(.|\n)*<!-- ${tag}stop -->`, 'm'), `<!-- ${tag} -->`)
+        readme = readme.replace(new RegExp(`<!-- ${tag} -->(.|\n|\r)*<!-- ${tag}stop -->`, 'm'), `<!-- ${tag} -->`)
       }
       this.log(`replacing <!-- ${tag} --> in README.md`)
     }


### PR DESCRIPTION
I encountered https://github.com/oclif/dev-cli/issues/107 and saw that there was already a proposed fix from @yippie for it. The change seemed to fix the issue for me, so I figured I'd make a PR for it