### PR TITLE
decrease build times for pack command

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,9 @@
     "oclif-typescript"
   ],
   "rules": {
-    "unicorn/no-abusive-eslint-disable": "off"
+    "unicorn/no-abusive-eslint-disable": "off",
+    "@typescript-eslint/no-use-before-define": ["error", {
+      "functions": false
+    }]
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,25 +14,33 @@
     "@oclif/plugin-help": "^3.2.0",
     "cli-ux": "^5.2.1",
     "debug": "^4.1.1",
+    "execa": "^5.0.0",
     "find-yarn-workspace-root": "^2.0.0",
     "fs-extra": "^8.1",
     "github-slugger": "^1.2.1",
     "lodash": "^4.17.11",
     "normalize-package-data": "^3.0.0",
     "qqjs": "^0.3.10",
-    "tslib": "^2.0.3"
+    "stream.pipeline-shim": "^1.1.0",
+    "tar": "^6.1.0",
+    "tmp": "^0.2.1",
+    "tslib": "^2.0.3",
+    "workerpool": "^6.1.0"
   },
   "devDependencies": {
     "@oclif/plugin-legacy": "^1.1.4",
     "@oclif/test": "^1.2.4",
     "@types/chai": "^4.1.7",
-    "@types/execa": "^0.9.0",
+    "@types/execa": "^2.0.0",
     "@types/fs-extra": "^9.0",
     "@types/lodash": "^4.14.123",
     "@types/lodash.template": "^4.4.6",
     "@types/mocha": "^7.0.2",
     "@types/node": "^14.0.14",
-    "@types/supports-color": "^5.3.0",
+    "@types/supports-color": "^7.2.0",
+    "@types/tar": "^4.0.4",
+    "@types/tmp": "^0.2.0",
+    "@types/workerpool": "^6.0.0",
     "@types/write-json-file": "^3.2.1",
     "aws-sdk": "^2.443.0",
     "chai": "^4.2.0",
@@ -46,7 +54,7 @@
     "typescript": "3.8.3"
   },
   "engines": {
-    "node": ">=8.10.0"
+    "node": ">= 8.0.0"
   },
   "files": [
     "/oclif.manifest.json",

--- a/src/tarballs/bin.ts
+++ b/src/tarballs/bin.ts
@@ -1,14 +1,17 @@
 /* eslint-disable no-useless-escape */
 import * as Config from '@oclif/config'
 import * as qq from 'qqjs'
+import * as fs from 'fs-extra'
+import * as path from 'path'
 
 export async function writeBinScripts({config, baseWorkspace, nodeVersion}: {config: Config.IConfig; baseWorkspace: string; nodeVersion: string}) {
   const binPathEnvVar = config.scopedEnvVarKey('BINPATH')
   const redirectedEnvVar = config.scopedEnvVarKey('REDIRECTED')
   const clientHomeEnvVar = config.scopedEnvVarKey('OCLIF_CLIENT_HOME')
+  await qq.mkdirp(qq.join([baseWorkspace, 'bin']))
   const writeWin32 = async () => {
     const {bin} = config
-    await qq.write([baseWorkspace, 'bin', `${config.bin}.cmd`], `@echo off
+    await fs.writeFile(path.join(baseWorkspace, 'bin', `${config.bin}.cmd`), `@echo off
 setlocal enableextensions
 
 if not "%${redirectedEnvVar}%"=="1" if exist "%LOCALAPPDATA%\\${bin}\\client\\bin\\${bin}.cmd" (
@@ -34,8 +37,8 @@ if exist "%~dp0..\\bin\\node.exe" (
     // `)
   }
   const writeUnix = async () => {
-    const bin = qq.join([baseWorkspace, 'bin', config.bin])
-    await qq.write(bin, `#!/usr/bin/env bash
+    const bin = path.join(baseWorkspace, 'bin', config.bin)
+    await fs.writeFile(bin, `#!/usr/bin/env bash
 set -e
 echoerr() { echo "$@" 1>&2; }
 

--- a/src/tarballs/gzip-worker.js
+++ b/src/tarballs/gzip-worker.js
@@ -1,0 +1,18 @@
+const {worker} = require('workerpool');
+const {createGzip} = require('zlib');
+const {pipeline: streamPipeline} = require('stream');
+const {promisify} = require('util');
+const fs = require('fs');
+
+const pipeline = promisify(streamPipeline);
+
+function gzip(filePath, target) {
+  const gzip = createGzip({level: 6});
+  const readStream = fs.createReadStream(filePath);
+  const writeStream = fs.createWriteStream(target);
+  return pipeline(readStream, gzip, writeStream).then(() => true);
+}
+
+worker({
+  gzip: gzip
+})

--- a/src/tarballs/node.ts
+++ b/src/tarballs/node.ts
@@ -1,8 +1,17 @@
 import {error as oclifError} from '@oclif/errors'
 import * as path from 'path'
 import * as qq from 'qqjs'
-
+import * as fs from 'fs'
+import * as crypto from 'crypto'
+import streamPipeline = require('stream.pipeline-shim')
+import {promisify} from 'util'
+import * as http from 'https'
+import * as tmp from 'tmp'
 import {log} from '../log'
+import * as tar from 'tar'
+import type {IncomingMessage} from 'http'
+
+const pipeline  = promisify(streamPipeline)
 
 async function checkFor7Zip() {
   try {
@@ -13,56 +22,182 @@ async function checkFor7Zip() {
   }
 }
 
-export async function fetchNodeBinary({nodeVersion, output, platform, arch, tmp}: {nodeVersion: string; output: string; platform: string; arch: string; tmp: string}) {
+interface DownloadOptions {
+  nodeVersion: string;
+  platform: string;
+  arch: string;
+}
+
+interface FetchNodeBinaryOptions extends DownloadOptions {
+  tmp: string;
+  output: string;
+  shasums: string;
+}
+
+function fetchText(url: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, res => {
+      const buffer: Buffer[] = []
+      if (res.statusCode! / 100 !== 2) {
+        return reject(new Error(`Invalid HTTPS request for url ${url}: Status Code ${res.statusCode}`))
+      }
+      res.on('data', d => {
+        buffer.push(d)
+      })
+      res.on('end', () => {
+        const body = Buffer.concat(buffer).toString()
+        resolve(body)
+      })
+    }).once('error', reject)
+
+    req.end()
+  })
+}
+
+function nodeURL(nodeVersion: string, path: string): string {
+  return `https://nodejs.org/dist/v${nodeVersion}${path}`
+}
+
+export function downloadSHASums(nodeVersion: string): Promise<string> {
+  return fetchText(nodeURL(nodeVersion, '/SHASUMS256.txt.asc'))
+}
+
+function getDownloadResponseStream(url: string): Promise<IncomingMessage> {
+  return new Promise((resolve, reject) => {
+    http.get(url, res => {
+      resolve(res)
+    })
+    .on('error', reject)
+  })
+}
+
+function findSHASum(fileName: string, shasums: string): string {
+  let sha
+  for (const line of shasums.split('\n')) {
+    const split = line.split(fileName)
+    if (split.length === 2) {
+      sha = split[0].trim()
+      break
+    }
+  }
+
+  if (!sha) {
+    throw new Error('missing shasum')
+  }
+
+  return sha
+}
+
+interface CacheNodeOptions {
+  url: string;
+  cacheDir: string;
+  downloadFileName: string;
+  cacheFileName: string;
+  sha: string;
+  files: string[];
+}
+
+async function extract7Zip(path: string, cacheDir: string) {
+  await qq.x(`7z x -bd -y '${path}' -o${cacheDir} > /dev/null`)
+}
+
+async function cacheNode({url, cacheFileName, sha, downloadFileName, cacheDir, files}: CacheNodeOptions) {
+  const stream = await getDownloadResponseStream(url)
+  const tmpDir = await promisify(tmp.dir)()
+  await qq.mkdirp(tmpDir)
+  const tmpFile = path.join(tmpDir, downloadFileName)
+  const cacheWriteStream = fs.createWriteStream(tmpFile)
+
+  try {
+    await pipeline(stream, cacheWriteStream)
+
+    const hash = crypto.createHash('sha256')
+    await pipeline(fs.createReadStream(tmpFile), hash)
+
+    if (hash.digest('hex') !== sha) {
+      throw new Error(`node.js download SHASUM mismatch: expected ${url} to have shasum of ${sha}, but got ${tarballSha}`)
+    }
+
+    if (url.endsWith('7z')) {
+      const ztmpdir = await promisify(tmp.dir)()
+
+      await qq.mkdirp(ztmpdir)
+      await extract7Zip(tmpFile, ztmpdir)
+
+      await qq.mv(path.join(ztmpdir, path.basename(tmpFile, '.7z'), 'node.exe'), cacheFileName)
+    } else {
+      await tar.extract({file: tmpFile, cwd: cacheDir}, files)
+    }
+  } finally {
+    cacheWriteStream.close()
+  }
+}
+
+function nodeFileName(nodeVersion: string, platform: string, arch: string): string {
+  return `node-v${nodeVersion}-${platform}-${arch}`
+}
+
+function nodeDownloadFileName(nodeVersion: string, platform: string, arch: string) {
+  if (platform === 'win32') {
+    return `node-v${nodeVersion}-win-${arch}.7z`
+  }
+  return `node-v${nodeVersion}-${platform}-${arch}.tar.gz`
+}
+
+function nodeDownloadURL(nodeVersion: string, platform: string, arch: string) {
+  const downloadFileName = nodeDownloadFileName(nodeVersion, platform, arch)
+  return nodeURL(nodeVersion, `/${downloadFileName}`)
+}
+
+function nodeOutputFileName(nodeVersion: string, platform: string, arch: string): string {
+  let nodeFile = nodeFileName(nodeVersion, platform, arch)
+
+  if (platform === 'win32') {
+    nodeFile += '.exe'
+  }
+
+  return nodeFile
+}
+
+export async function fetchNodeBinary(options: FetchNodeBinaryOptions) {
+  const {tmp, shasums, output, platform, nodeVersion} = options
+  let {arch} = options
   if (arch === 'arm') arch = 'armv7l'
-  let nodeBase = `node-v${nodeVersion}-${platform}-${arch}`
-  let tarball = path.join(tmp, 'node', `${nodeBase}.tar.xz`)
-  let url = `https://nodejs.org/dist/v${nodeVersion}/${nodeBase}.tar.xz`
+
+  const cacheDir = path.join(tmp, 'cache')
+  const nodeDir = path.join(tmp, 'node')
+
+  const sha = findSHASum(nodeDownloadFileName(nodeVersion, platform, arch), shasums)
+
+  const nodeBase = nodeFileName(nodeVersion, platform, arch)
+  const outputFileName = nodeOutputFileName(nodeVersion, platform, arch)
+  const cacheFileName = path.join(cacheDir, outputFileName)
+  let targetFileName = path.join(nodeDir, outputFileName)
+
+  if (platform === 'win32') {
+    targetFileName = `${targetFileName}.exe`
+  }
+
+  const config: CacheNodeOptions = {
+    url: nodeDownloadURL(nodeVersion, platform, arch),
+    downloadFileName: nodeDownloadFileName(nodeVersion, platform, arch),
+    cacheDir: cacheDir,
+    files: [outputFileName],
+    cacheFileName,
+    sha,
+  }
+
   if (platform === 'win32') {
     await checkFor7Zip()
-    // eslint-disable-next-line require-atomic-updates
-    nodeBase = `node-v${nodeVersion}-win-${arch}`
-    tarball = path.join(tmp, 'node', `${nodeBase}.7z`)
-    url = `https://nodejs.org/dist/v${nodeVersion}/${nodeBase}.7z`
-    output += '.exe'
   }
 
-  let cache = path.join(tmp, 'cache', `node-v${nodeVersion}-${platform}-${arch}`)
-  if (platform === 'win32') cache += '.exe'
+  await qq.mkdirp(cacheDir)
 
-  const download = async () => {
+  if (!await qq.exists(cacheFileName)) {
     log(`downloading ${nodeBase}`)
-    const shasums = path.join(tmp, 'cache', nodeVersion, 'SHASUMS256.txt.asc')
-    if (!await qq.exists(shasums)) {
-      await qq.download(`https://nodejs.org/dist/v${nodeVersion}/SHASUMS256.txt.asc`, shasums)
-    }
-    const basedir = path.dirname(tarball)
-    await qq.mkdirp(basedir)
-    await qq.download(url, tarball)
-    await qq.x(`grep ${path.basename(tarball)} ${shasums} | shasum -a 256 -c -`, {cwd: basedir})
+    await qq.mkdirp(path.dirname(targetFileName))
+    await cacheNode(config)
   }
-  const extract = async () => {
-    log(`extracting ${nodeBase}`)
-    const nodeTmp = path.join(tmp, 'node')
-    await qq.rm([nodeTmp, nodeBase])
-    await qq.mkdirp(nodeTmp)
-    await qq.mkdirp(path.dirname(cache))
-    if (platform === 'win32') {
-      qq.pushd(nodeTmp)
-      await qq.x(`7z x -bd -y ${tarball} > /dev/null`)
-      await qq.mv([nodeBase, 'node.exe'], cache)
-      qq.popd()
-    } else {
-      await qq.x(`tar -C ${tmp}/node -xJf ${tarball}`)
-      await qq.mv([nodeTmp, nodeBase, 'bin/node'], cache)
-    }
-  }
-  if (await qq.exists(cache)) {
-    await qq.cp(cache, output)
-  } else {
-    await download()
-    await extract()
-    await qq.cp(cache, output)
-  }
-  return output
+
+  await qq.cp(cacheFileName, output)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -205,12 +205,12 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
-"@types/execa@^0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@types/execa/-/execa-0.9.0.tgz#9b025d2755f17e80beaf9368c3f4f319d8b0fb93"
-  integrity sha512-mgfd93RhzjYBUHHV532turHC2j4l/qxsF/PbfDmprHDEUHmNZGlDn1CEsulGK3AfsPdhkWzZQT/S/k0UGhLGsA==
+"@types/execa@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/execa/-/execa-2.0.0.tgz#4dd5523520c51834bf8d0c280f460814e5238281"
+  integrity sha512-aBnkJ0r3khaZkHzu9pDZeWXrDg1N/ZtDGRQkK+KIqNVvvTvW+URXMUHQQCQMYdb2GPrcwu9Fq6l9iiT+pirIbg==
   dependencies:
-    "@types/node" "*"
+    execa "*"
 
 "@types/fs-extra@^9.0":
   version "9.0.7"
@@ -255,10 +255,22 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
-"@types/mocha@*", "@types/mocha@^8.0.0":
+"@types/minipass@*":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@types/minipass/-/minipass-2.2.0.tgz#51ad404e8eb1fa961f75ec61205796807b6f9651"
+  integrity sha512-wuzZksN4w4kyfoOv/dlpov4NOunwutLA/q7uc00xU02ZyUY+aoM5PWIXEKBMnm0NHd4a+N71BMjq+x7+2Af1fg==
+  dependencies:
+    "@types/node" "*"
+
+"@types/mocha@*":
   version "8.2.1"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-8.2.1.tgz#f3f3ae4590c5386fc7c543aae9b78d4cf30ffee9"
   integrity sha512-NysN+bNqj6E0Hv4CTGWSlPzMW6vTKjDpOteycDkV4IWBsO+PU48JonrPzV9ODjiI2XrjmA05KInLgF5ivZ/YGQ==
+
+"@types/mocha@^7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-7.0.2.tgz#b17f16cf933597e10d6d78eae3251e692ce8b0ce"
+  integrity sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==
 
 "@types/nock@*":
   version "10.0.3"
@@ -286,6 +298,26 @@
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@types/supports-color/-/supports-color-7.2.0.tgz#edd98ae52ee786b733a5dea0a23da4eb18ef7310"
   integrity sha512-gtUcOP6qIpjbSDdWjMBRNSks42ccx1709mwKTgelW63BESIADw8Ju7klpydDDb9Kr0iRXfpwrXH8+zoU8TCqiA==
+
+"@types/tar@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@types/tar/-/tar-4.0.4.tgz#d680de60855e7778a51c672b755869a3b8d2889f"
+  integrity sha512-0Xv+xcmkTsOZdIF4yCnd7RkOOyfyqPaqJ7RZFKnwdxfDbkN3eAAE9sHl8zJFqBz4VhxolW9EErbjR1oyH7jK2A==
+  dependencies:
+    "@types/minipass" "*"
+    "@types/node" "*"
+
+"@types/tmp@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.0.tgz#e3f52b4d7397eaa9193592ef3fdd44dc0af4298c"
+  integrity sha512-flgpHJjntpBAdJD43ShRosQvNC0ME97DCfGvZEDlAThQmnerRXrLbX6YgzRBQCZTthET9eAWFAMaYP0m0Y4HzQ==
+
+"@types/workerpool@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@types/workerpool/-/workerpool-6.0.0.tgz#068c31191f7df9b3d49ebe348b1eeb601e75e2d3"
+  integrity sha512-BjbKVHFBWblQ3vZ5yFq29kbM2TsaUaTOwYgVxqnNjMrT6CktVF8AvMxOJZgHGgNbAzP4z8DK+EshyZcYpdvAhQ==
+  dependencies:
+    "@types/node" "*"
 
 "@types/write-json-file@^3.2.1":
   version "3.2.1"
@@ -670,6 +702,11 @@ chownr@^1.1.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.2.tgz#a18f1e0b269c8a6a5d3c86eb298beb14c3dd7bf6"
   integrity sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==
 
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
+
 clean-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/clean-regexp/-/clean-regexp-1.0.0.tgz#8df7c7aae51fd36874e8f8d05b9180bc11a3fed7"
@@ -996,7 +1033,7 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.2:
+cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -1067,6 +1104,13 @@ deep-is@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+
+define-properties@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
+  dependencies:
+    object-keys "^1.0.12"
 
 detect-indent@^6.0.0:
   version "6.0.0"
@@ -1361,6 +1405,21 @@ events@1.1.1:
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
   integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
 
+execa@*, execa@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-5.0.0.tgz#4029b0007998a841fbd1032e5f4de86a3c1e3376"
+  integrity sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^6.0.0"
+    human-signals "^2.1.0"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.1"
+    onetime "^5.1.2"
+    signal-exit "^3.0.3"
+    strip-final-newline "^2.0.0"
+
 execa@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.10.0.tgz#ff456a8f53f90f8eccc71a96d11bdfc7f082cb50"
@@ -1535,6 +1594,13 @@ fs-extra@^8.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-minipass@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
+  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
+  dependencies:
+    minipass "^3.0.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1592,6 +1658,11 @@ get-stream@^5.1.0:
   integrity sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
   dependencies:
     pump "^3.0.0"
+
+get-stream@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.0.tgz#3e0012cb6827319da2706e601a1583e8629a6718"
+  integrity sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==
 
 git-raw-commits@2.0.0:
   version "2.0.0"
@@ -1771,6 +1842,11 @@ http-call@^5.1.2, http-call@^5.2.4:
     is-stream "^2.0.0"
     parse-json "^4.0.0"
     tunnel-agent "^0.6.0"
+
+human-signals@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
+  integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
 hyperlinker@^1.0.0:
   version "1.0.0"
@@ -2170,7 +2246,7 @@ lodash.zip@^4.2.0:
   resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
   integrity sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=
 
-lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20:
+lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.20:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -2272,7 +2348,17 @@ meow@^8.0.0:
     type-fest "^0.18.0"
     yargs-parser "^20.2.3"
 
-merge2@^1.2.3, merge2@^1.3.0:
+merge-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
+  integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
+
+merge2@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.3.tgz#7ee99dbd69bb6481689253f018488a1b902b0ed5"
+  integrity sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==
+
+merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
@@ -2284,6 +2370,11 @@ micromatch@^4.0.2:
   dependencies:
     braces "^3.0.1"
     picomatch "^2.0.5"
+
+mimic-fn@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
+  integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
 min-indent@^1.0.0:
   version "1.0.1"
@@ -2329,12 +2420,32 @@ minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
+minipass@^3.0.0:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.3.tgz#7d42ff1f39635482e15f9cdb53184deebd5815fd"
+  integrity sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==
+  dependencies:
+    yallist "^4.0.0"
+
+minizlib@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
+  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
+  dependencies:
+    minipass "^3.0.0"
+    yallist "^4.0.0"
+
 mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+mkdirp@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 mocha@^8.2.1:
   version "8.3.0"
@@ -2452,6 +2563,13 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
+npm-run-path@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
+  integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
+  dependencies:
+    path-key "^3.0.0"
+
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
@@ -2461,6 +2579,11 @@ object-assign@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+
+object-keys@^1.0.12:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
+  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
 object-treeify@^1.1.4:
   version "1.1.25"
@@ -2473,6 +2596,13 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
+
+onetime@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
+  integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
+  dependencies:
+    mimic-fn "^2.1.0"
 
 open@^6.2.0:
   version "6.3.0"
@@ -2622,7 +2752,7 @@ path-key@^2.0.0, path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
-path-key@^3.1.0:
+path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
@@ -2953,7 +3083,7 @@ rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.2:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -3057,6 +3187,11 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
+signal-exit@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
+  integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -3144,6 +3279,23 @@ stdout-stderr@^0.1.9:
     debug "^3.1.0"
     strip-ansi "^4.0.0"
 
+stream.finished@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/stream.finished/-/stream.finished-1.2.0.tgz#40fc76092792d08a43388184fd0d42c6ab9523a0"
+  integrity sha512-xSp45f/glqd035qAtFUxAGvhotjY/EfqDNV+rQW8o7ffligiOjPaguTEvRzeQAhiQMCdkPEBrp5++S/rQyavWQ==
+  dependencies:
+    define-properties "^1.1.3"
+    function-bind "^1.1.1"
+
+stream.pipeline-shim@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/stream.pipeline-shim/-/stream.pipeline-shim-1.1.0.tgz#70c94a5f9a1ab84951694a2cc108bc7a47000cb5"
+  integrity sha512-pSi/SZZDbSA5l3YYjSmJadCoD74/qSe79r9ZVR21lD4bpf+khn5Umi6AlfJrD8I0KQfGSqm/7Yp48dmithM+Vw==
+  dependencies:
+    define-properties "^1.1.3"
+    function-bind "^1.1.1"
+    stream.finished "^1.2.0"
+
 "string-width@^1.0.2 || 2", string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
@@ -3217,6 +3369,11 @@ strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
   integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
+
+strip-final-newline@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
+  integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
 strip-indent@^1.0.1:
   version "1.0.1"
@@ -3310,6 +3467,18 @@ tar-stream@^2.0.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
+tar@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.0.tgz#d1724e9bcc04b977b18d5c573b333a2207229a83"
+  integrity sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
+
 temp-dir@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-2.0.0.tgz#bde92b05bdfeb1516e804c9c00ad45177f31321e"
@@ -3359,6 +3528,13 @@ tmp@^0.1.0:
   integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==
   dependencies:
     rimraf "^2.6.3"
+
+tmp@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
+  integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
+  dependencies:
+    rimraf "^3.0.0"
 
 to-regex-range@^5.0.1:
   version "5.0.1"
@@ -3571,7 +3747,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
-workerpool@6.1.0:
+workerpool@6.1.0, workerpool@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.1.0.tgz#a8e038b4c94569596852de7a8ea4228eefdeb37b"
   integrity sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==


### PR DESCRIPTION
We can reuse the tarball and append new files (node binaries in this case) instead of compressing/extracting multiple times. This prevents un-necessary copying of files in the built tarball.

We can also build all `targets` in parallel in the following way:

- Download Node.js versions for targets in parallel instead of serially
- Use [workerpool][1] to create gzip files in parallel
- Run all `xz` compression with maximum available threads. xz has [supported multicore computation since 5.2 (2014)][1].
- Like gzip, run all `xz` compression in parallel instead of waiting for each target to build.

Running this in the Heroku CLI produced identical tarballs in 65% amount of time (~111s seconds vs ~344 seconds before this change). It's likely even a bit faster since I was running it locally which has some boot-up time due to ts-node compiling typescript at runtime.

This file brings in the `tar` dependency. This dependency is maintained by the npm team and is also cross-platform. This gets us quite a bit closer to allow building OClif CLIs on windows!

[1]: https://www.npmjs.com/package/workerpool
[2]: https://www.phoronix.com/scan.php?page=news_item&px=MTg3MDM
