### PR TITLE
build: use circleci orb to install node/yarn

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,6 @@ jobs:
           pkg-manager: yarn
           include-branch-in-cache-key: false
       - run: 'echo "Node: `node --version`"'
-      - run: .circleci/loadgpg
       - run: yarn add -D nyc@13 @oclif/nyc-config@1
       - run: ./node_modules/.bin/tsc
       - run: ./bin/run --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,13 @@
 ---
-version: 2
+version: 2.1
+orbs:
+  node: circleci/node@4.2.0
 jobs:
-  node-12: &test
+  test-node: &test
+    parameters:
+      node-version:
+        type: string
+        description: "node.js version to install"
     docker:
       - image: oclif/nsis:12.0.0-16
     working_directory: ~/cli
@@ -9,12 +15,28 @@ jobs:
       NYC: "yarn exec nyc -- --nycrc-path node_modules/@oclif/nyc-config/.nycrc"
     steps:
       - checkout
-      - restore_cache: &restore_cache
-          keys:
-            - v6-yarn-{{checksum ".circleci/config.yml"}}-{{ checksum "yarn.lock"}}
-            - v6-yarn-{{checksum ".circleci/config.yml"}}
+      - run: &setup_yarn
+          name: Setup Yarn
+          command: |
+            mkdir -p .yarn
+            echo "--install.cache-path $(pwd)/.yarn/cache" >> .yarnrc
+            echo "yarn-offline-mirror $(pwd)/.yarn/offline-mirror" >> .yarnrc
+      - node/install: &install_node
+          install-yarn: true
+          node-version: << parameters.node-version >>
+      - run: &create_cache_key_file
+          name: "Create Cache Key File"
+          command: |
+            echo "node: $(node --version)" >> .circleci-cache-key
+            echo "yarn: $(yarn --version)" >> .circleci-cache-key
+            echo "yarnrc: $(sha256sum .yarnrc)" >> .circleci-cache-key
+            echo ".circleci/config.yml: $(sha256sum .circleci/config.yml)" >> .circleci-cache-key
+      - node/install-packages: &install_node_packages
+          cache-version: &cache_key |
+            {{checksum ".circleci-cache-key"}}
+          pkg-manager: yarn
+          include-branch-in-cache-key: false
       - run: 'echo "Node: `node --version`"'
-      - run: yarn
       - run: .circleci/loadgpg
       - run: yarn add -D nyc@13 @oclif/nyc-config@1
       - run: ./node_modules/.bin/tsc
@@ -23,17 +45,16 @@ jobs:
       - run: |
           $NYC yarn test
           curl -s https://codecov.io/bash | bash
-  node-10:
-    <<: *test
-    docker:
-      - image: chadian/nsis:10-2
   release:
     <<: *test
     steps:
       - add_ssh_keys
       - checkout
+      - run: *setup_yarn
+      - node/install: *install_node
+      - run: *create_cache_key_file
+      - node/install-packages: *install_node_packages
       - run: .circleci/loadgpg
-      - restore_cache: *restore_cache
       - run: yarn global add @oclif/semantic-release@3 semantic-release@17
       - run: yarn --frozen-lockfile
       - run: ./bin/run pack
@@ -55,15 +76,20 @@ jobs:
             - /usr/local/share/.config/yarn
 
 workflows:
-  version: 2
-  "@oclif/dev-cli":
+  version: 2.1
+  build:
     jobs:
-      - node-12
-      - node-10
+      - test-node:
+          matrix:
+            parameters:
+              node-version:
+                - "10"
+                - "12"
+                - "14"
       - release:
+          node-version: "14"
           context: org-global
           filters:
             branches: {only: master}
           requires:
-            - node-12
-            - node-10
+            - test-node

--- a/yarn.lock
+++ b/yarn.lock
@@ -255,10 +255,15 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
-"@types/mocha@*", "@types/mocha@^8.0.0":
+"@types/mocha@*":
   version "8.2.1"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-8.2.1.tgz#f3f3ae4590c5386fc7c543aae9b78d4cf30ffee9"
   integrity sha512-NysN+bNqj6E0Hv4CTGWSlPzMW6vTKjDpOteycDkV4IWBsO+PU48JonrPzV9ODjiI2XrjmA05KInLgF5ivZ/YGQ==
+
+"@types/mocha@^7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-7.0.2.tgz#b17f16cf933597e10d6d78eae3251e692ce8b0ce"
+  integrity sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==
 
 "@types/nock@*":
   version "10.0.3"
@@ -282,10 +287,10 @@
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-7.0.12.tgz#18412939ae45b225bd38715a25c1040cbad80f42"
   integrity sha512-fo0MWpVPSUrnZZhp9wyu+hhI3VJ9+Jhs+PWrokBTg3d2ryNPDOAWF1csIhQuYWBTn7KdZzXpRgpX2o6cwOlPWg==
 
-"@types/supports-color@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@types/supports-color/-/supports-color-7.2.0.tgz#edd98ae52ee786b733a5dea0a23da4eb18ef7310"
-  integrity sha512-gtUcOP6qIpjbSDdWjMBRNSks42ccx1709mwKTgelW63BESIADw8Ju7klpydDDb9Kr0iRXfpwrXH8+zoU8TCqiA==
+"@types/supports-color@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@types/supports-color/-/supports-color-5.3.0.tgz#eb6a52e9531fb3ebcd401cec774d1bdfb571f793"
+  integrity sha512-WxwTXnHTIsk7srax1icjLgX+6w1MUAJbhyCpRP/45paEElsPDQUJZDgr1UpKuL2S3Tb+ZyX9MjWwmcSD4bUoOQ==
 
 "@types/write-json-file@^3.2.1":
   version "3.2.1"
@@ -2170,7 +2175,7 @@ lodash.zip@^4.2.0:
   resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
   integrity sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=
 
-lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20:
+lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.20:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
This will help the build not break when we need a later version of node
that is within range.