### PR TITLE
Fix tarball packing in paths with spaces

### DIFF
--- a/src/tarballs/build.ts
+++ b/src/tarballs/build.ts
@@ -37,7 +37,7 @@ export async function build(c: IConfig, options: {
     tarball = path.basename(tarball)
     tarball = qq.join([c.workspace(), tarball])
     qq.cd(c.workspace())
-    await qq.x(`tar -xzf ${tarball}`)
+    await qq.x(`tar -xzf "${tarball}"`)
     // eslint-disable-next-line no-await-in-loop
     for (const f of await qq.ls('package', {fullpath: true})) await qq.mv(f, '.')
     await qq.rm('package', tarball, 'bin/run.cmd')

--- a/src/tarballs/node.ts
+++ b/src/tarballs/node.ts
@@ -39,7 +39,7 @@ export async function fetchNodeBinary({nodeVersion, output, platform, arch, tmp}
     const basedir = path.dirname(tarball)
     await qq.mkdirp(basedir)
     await qq.download(url, tarball)
-    await qq.x(`grep ${path.basename(tarball)} ${shasums} | shasum -a 256 -c -`, {cwd: basedir})
+    await qq.x(`grep "${path.basename(tarball)}" "${shasums}" | shasum -a 256 -c -`, {cwd: basedir})
   }
   const extract = async () => {
     log(`extracting ${nodeBase}`)
@@ -49,11 +49,11 @@ export async function fetchNodeBinary({nodeVersion, output, platform, arch, tmp}
     await qq.mkdirp(path.dirname(cache))
     if (platform === 'win32') {
       qq.pushd(nodeTmp)
-      await qq.x(`7z x -bd -y ${tarball} > /dev/null`)
+      await qq.x(`7z x -bd -y "${tarball}" > /dev/null`)
       await qq.mv([nodeBase, 'node.exe'], cache)
       qq.popd()
     } else {
-      await qq.x(`tar -C ${tmp}/node -xJf ${tarball}`)
+      await qq.x(`tar -C "${tmp}/node" -xJf "${tarball}"`)
       await qq.mv([nodeTmp, nodeBase, 'bin/node'], cache)
     }
   }


### PR DESCRIPTION
Today, if the project is in a path that contains spaces, `oclif-dev pack` will fail (at various stages) because the raw path is passed unquoted to subcommands, which then treat either side of the space as separate arguments.

This tiny PR just wraps a few relevant arguments with quotes. This fixes this issue for me at least (building on Linux).